### PR TITLE
Fix: defined loadedImages state for image loader visibility

### DIFF
--- a/src/Components/Card.js
+++ b/src/Components/Card.js
@@ -10,6 +10,8 @@ const Card = ({ products }) => {
   const [hoveredProduct, setHoveredProduct] = useState(null);
   const [imageHeights, setImageHeights] = useState({});
   const containerRef = useRef(null);
+  const [loadedImages, setLoadedImages] = useState({});
+
 
   const navigate = useNavigate();
 
@@ -146,6 +148,12 @@ const Card = ({ products }) => {
       ...prev,
       [productId]: height
     }));
+
+    
+  setLoadedImages(prev => ({
+    ...prev,
+    [productId]: true
+  }));
   };
 
   return (
@@ -192,9 +200,29 @@ const Card = ({ products }) => {
             >
               {/* Product Image Section - Responsive Dynamic Height */}
               <div 
-                className="relative overflow-hidden"
-                style={{ height: `${getDynamicImageHeight(index)}px` }}
-              >
+  className="relative overflow-hidden"
+  style={{ height: `${getDynamicImageHeight(index)}px` }}
+>
+  {!loadedImages[product._id] && (
+    <div
+      role="status"
+      className="absolute inset-0 flex items-center justify-center bg-gray-300 animate-pulse z-10"
+    >
+      <svg
+        className="w-10 h-10 text-gray-200"
+        aria-hidden="true"
+        xmlns="https://loading.io/icon/f0nltz"
+        fill="currentColor"
+        viewBox="0 0 16 20"
+      >
+        <path d="M5 5V.13a2.96 2.96 0 0 0-1.293.749L.879 3.707A2.98 2.98 0 0 0 .13 5H5Z" />
+        <path d="M14.066 0H7v5a2 2 0 0 1-2 2H0v11a1.97 1.97 0 0 0 1.934 2h12.132A1.97 1.97 0 0 0 16 18V2a1.97 1.97 0 0 0-1.934-2ZM9 13a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-2a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2Zm4 .382a1 1 0 0 1-1.447.894L10 13v-2l1.553-1.276a1 1 0 0 1 1.447.894v2.764Z" />
+      </svg>
+      <span className="sr-only">Loading...</span>
+    </div>
+  )}
+
+
                 <img
                   src={product.images?.[0]?.url || `https://picsum.photos/300/${getDynamicImageHeight(index)}?random=${index}`}
                   alt={product.productName || 'Product Image'}


### PR DESCRIPTION
Title: Fix: Defined loadedImages state to show loader until image is loaded

- Fixed ESLint error by declaring `loadedImages` state.
- Implemented per-card loader animation while images load.
- Improves UX and prevents blank image flashes.

Fixes #18
